### PR TITLE
updated the expect value, last two chunks 7 chars and trailing spaces

### DIFF
--- a/exercises/practice/crypto-square/run_test.v
+++ b/exercises/practice/crypto-square/run_test.v
@@ -44,6 +44,6 @@ fn test_8_character_plaintext_results_in_3_chunks_the_last_one_with_a_trailing_s
 
 fn test_54_character_plaintext_results_in_7_chunks_the_last_two_with_trailing_spaces() {
 	phrase := 'If man was meant to stay on the ground, god would have given us roots.'
-	expect := 'imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau '
+	expect := 'isotnugr fmshdlio metegdvo aaagohet nnyrdans wtoowvu atnuoes  '
 	assert ciphertext(phrase) == expect
 }


### PR DESCRIPTION
If all chunks except last two chunks should have 8 characters, then this should fix the issue.
But I am not sure, if the chunk before last chunk should have 8 chars and not seven. 

